### PR TITLE
chore: bump freshrss chart to 1.21.0

### DIFF
--- a/charts/freshrss/Chart.yaml
+++ b/charts/freshrss/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.20.2"
+appVersion: "1.21.0"

--- a/charts/freshrss/values.yaml
+++ b/charts/freshrss/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: freshrss/freshrss
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.20.2"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Changes:
- Bump appVersion to 1.21.0
- Remove image tag in favour of chart appVersion