### PR TITLE
chore: bump tandoor 1.5.14

### DIFF
--- a/charts/tandoor-recipes/Chart.yaml
+++ b/charts/tandoor-recipes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tandoor-recipes/Chart.yaml
+++ b/charts/tandoor-recipes/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.13"
+appVersion: "1.5.14"
 
 dependencies:
   - name: postgresql

--- a/charts/tandoor-recipes/templates/deployment.yaml
+++ b/charts/tandoor-recipes/templates/deployment.yaml
@@ -67,12 +67,14 @@ spec:
                   key: password
           livenessProbe:
             httpGet:
-              path: /
+              path: /accounts/login/
               port: http
-          readinessProbe:
+          startupProbe:
             httpGet:
-              path: /
+              path: /accounts/login/
               port: http
+            periodSeconds: 3
+            failureThreshold: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Changes:
- bump tandoor-recipes to 1.5.14
- replace `readinessProbe` with `startupProbe` to account for long first-time startup
- set health check path to prevent redirect